### PR TITLE
Fix - date.timezone no value

### DIFF
--- a/dockerfiles/php/Dockerfile
+++ b/dockerfiles/php/Dockerfile
@@ -23,6 +23,7 @@ RUN tar -xf /usr/src/php/ext/amqp.tgz -C /usr/src/php/ext/ && \
 # Configurations
 RUN ln -sf /usr/share/zoneinfo/Europe/Paris /etc/localtime
 
+RUN echo "date.timezone = \"Europe/Paris\"" > /usr/local/etc/php/conf.d/timezone.ini
 
 # Set working directory.
 WORKDIR /app


### PR DESCRIPTION
PHP ne dispose pas de valeur par défaut de `date.timezone` dans le php.ini. Cela provoque un warning :
```
Warning: date_default_timezone_get(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in /app/vendor/monolog/monolog/src/Monolog/Logger.php on line 252
```